### PR TITLE
Release v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,49 @@
+# Changelog
+
+All notable changes to the USASpending ORM library are documented here.
+The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and the project adheres to [Semantic Versioning](https://semver.org/).
+
+## [0.7.1] - 2026-04-16
+
+### Added
+
+- Public export of `DetachedInstanceError` so callers can `from usaspending import DetachedInstanceError` as documented in the README.
+- `config.allowed_download_hosts`: an allow-list of hostnames the library will fetch binary downloads from. Defaults to `{"api.usaspending.gov", "files.usaspending.gov"}`.
+- `config.validate()` now rejects malformed `base_url`, CR/LF in `user_agent`, and empty `cache_dir`.
+
+### Changed
+
+- `ValidationError` now inherits from both `USASpendingError` and the built-in `ValueError`. Callers that previously caught `ValueError` for invalid parameters continue to work unchanged; new code can catch the library-specific `ValidationError`.
+- `RateLimiter` now raises `ValidationError` (rather than a bare `ValueError`) for invalid `max_calls`/`period` arguments. Non-breaking due to the dual inheritance above.
+- `RecipientsResource.find_by_recipient_id` is now annotated as non-Optional. This matches its long-standing behavior of raising on miss via the direct-ID lookup path; runtime behavior is unchanged. `find_by_duns` and `find_by_uei` remain Optional because they use the search-delegation path.
+- `Agency.get_obligations` return annotation corrected from `float | None` to `Decimal | None` to match actual runtime type.
+- `Agency.total_obligations` now applies `Decimal` coercion to stored values to match its declared return type.
+- `TransactionsSearch._award_id` and `FundingSearch._award_id` annotated as `str | None` rather than `str` (they are always `None` until set).
+- `time_period()` now rejects date ranges where `end_date` is earlier than `start_date`.
+
+### Fixed
+
+- `to_date()` now extracts the `date` portion from `datetime` inputs instead of passing them through unchanged.
+- `IDVChildAwardsSearch._clone()` no longer silently drops `_filter_objects`, `_max_pages`, `_order_by`, and `_order_direction` when chaining.
+- `SubAwardsSearch._clone()` now delegates to `super()._clone()` so base-class state changes propagate.
+- `AwardAccountsQuery._clone()` no longer copies a stale `_cached_count` across filter changes.
+- `Agency.latest_action_date` no longer crashes when the award-summary endpoint returns no data.
+- `round_to_millions()` cleaned up redundant disjunct in threshold check.
+- Removed unused `DEFAULT_KEEP_UPPERCASE` set, which also contained a latent missing-comma bug that concatenated two entries.
+- Fixed malformed `Raises:` block in `AwardResource.find_by_generated_id` docstring.
+- `Agency.id` was missing its return-type annotation.
+
+### Security
+
+- Binary downloads (`_download_binary_file`) now require `https` and a hostname on `config.allowed_download_hosts`, mitigating SSRF if API responses are tampered with.
+- File-backed cache directory is now created with `0700` and tightened to `0700` if it already exists with looser bits. Protects the pickle-backed cache on shared hosts.
+- ZIP extraction creates the extract directory with `0700`, detects absolute paths with stdlib `posixpath.isabs` / `ntpath.isabs` (covers Windows drive letters and UNC prefixes), and uses `normpath`-based prefix comparison for traversal detection.
+
+### Removed
+
+- Dead code: `get_past_fiscal_years`, `custom_titlecase_callback`, `parse_agency_type`, `parse_agency_tier`, `QueryBuilder._fetch_page`, empty `AwardsSearch.__init__`, redundant `AwardsSearch._clone` override, unreachable `try/except` in `_derived_award_identifier`.
+
+## [0.7.0] - 2026-04-12
+
+Previous release. See git history for details.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "usaspending-orm"
-version = "0.7.0"
+version = "0.7.1"
 description = "A Python ORM wrapper for the USAspending.gov API with intuitive queries, automatic pagination, and smart caching"
 authors = [
     {name = "Casey Dreier", email = "casey.dreier@planetary.org"}

--- a/src/usaspending/__init__.py
+++ b/src/usaspending/__init__.py
@@ -26,6 +26,7 @@ from .config import config
 from .exceptions import (
     APIError,
     ConfigurationError,
+    DetachedInstanceError,
     DownloadError,
     HTTPError,
     RateLimitError,
@@ -102,6 +103,7 @@ __all__ = [
     "AwardsSearch",
     "ConfigurationError",
     "Contract",
+    "DetachedInstanceError",
     "DistrictSpending",
     "DownloadError",
     "Funding",

--- a/src/usaspending/client.py
+++ b/src/usaspending/client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import time
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urljoin
@@ -10,7 +11,7 @@ import cachier
 import requests
 
 from .config import config, register_cache_settings_observer
-from .exceptions import APIError, HTTPError, RateLimitError, ValidationError
+from .exceptions import APIError, DownloadError, HTTPError, RateLimitError, ValidationError
 from .logging_config import USASpendingLogger, log_api_request, log_api_response
 
 if TYPE_CHECKING:
@@ -527,10 +528,6 @@ class USASpendingClient:
         Raises:
             DownloadError: If download fails
         """
-        import os
-
-        from .exceptions import DownloadError
-
         # Construct full URL
         if file_url.startswith("http"):
             download_url = file_url

--- a/src/usaspending/client.py
+++ b/src/usaspending/client.py
@@ -390,6 +390,7 @@ class USASpendingClient:
 
         # Track request timing
         start_time = time.time()
+        response: requests.Response | None = None
 
         try:
             # Make request with retry
@@ -498,8 +499,8 @@ class USASpendingClient:
             return data
 
         except Exception as e:
-            # Log any unexpected errors
-            if "response" in locals():
+            # response is None if the exception fired before the HTTP round-trip
+            if response is not None:
                 error_msg_with_context = self._format_error_with_context(str(e))
                 log_api_response(
                     logger,

--- a/src/usaspending/client.py
+++ b/src/usaspending/client.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 import time
 from typing import TYPE_CHECKING, Any
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 
 import cachier
 import requests
@@ -534,6 +534,23 @@ class USASpendingClient:
             download_url = file_url
         else:
             download_url = urljoin(config.base_url, file_url.lstrip("/"))
+
+        # Restrict downloads to the configured allow-list of hosts. The API
+        # returns absolute file_url values; allow-listing prevents SSRF if
+        # the response is tampered with (e.g., redirected to metadata
+        # endpoints or attacker-controlled hosts).
+        parsed_download = urlparse(download_url)
+        if parsed_download.scheme != "https":
+            raise DownloadError(
+                f"Refusing to download over non-https scheme: {parsed_download.scheme!r}",
+                file_name=os.path.basename(destination_path),
+            )
+        if parsed_download.hostname not in config.allowed_download_hosts:
+            raise DownloadError(
+                f"Download host {parsed_download.hostname!r} is not in "
+                f"config.allowed_download_hosts.",
+                file_name=os.path.basename(destination_path),
+            )
 
         logger.info(f"Downloading binary file from {download_url}")
 

--- a/src/usaspending/config.py
+++ b/src/usaspending/config.py
@@ -83,6 +83,11 @@ class _Config:
         self.cache_ttl: timedelta = timedelta(weeks=1)
         self.cache_timeout: int = 60  # Seconds to wait for processing cache entries
 
+        # Tracks the path most recently prepared by
+        # _ensure_cache_dir_permissions so the stat/chmod triple only
+        # runs when the user actually changes cache_dir.
+        self._cache_dir_prepared: str | None = None
+
         # Apply the initial default settings when the object is created
         self._apply_cachier_settings()
 
@@ -134,10 +139,33 @@ class _Config:
 
         if self.cache_enabled:
             cachier.enable_caching()
+            self._ensure_cache_dir_permissions()
         else:
             cachier.disable_caching()
 
         _notify_cache_settings_observers()
+
+    def _ensure_cache_dir_permissions(self) -> None:
+        """Create the cache directory with restrictive permissions.
+
+        File-based caches use pickle, so write access by another local user
+        is a code-execution risk. We create the directory with 0700 and
+        tighten permissions if it already exists with looser bits. The
+        result is memoized so repeat `configure()` calls don't re-syscall.
+        """
+        if self.cache_backend != "file":
+            return
+        if self._cache_dir_prepared == self.cache_dir:
+            return
+        try:
+            os.makedirs(self.cache_dir, mode=0o700, exist_ok=True)
+            if os.name == "posix":
+                current_mode = os.stat(self.cache_dir).st_mode & 0o777
+                if current_mode & 0o077:
+                    os.chmod(self.cache_dir, 0o700)
+            self._cache_dir_prepared = self.cache_dir
+        except OSError as e:
+            logger.warning(f"Could not enforce 0700 permissions on cache dir {self.cache_dir}: {e}")
 
     def validate(self) -> None:
         """Validate the current configuration values."""

--- a/src/usaspending/config.py
+++ b/src/usaspending/config.py
@@ -4,6 +4,7 @@ import os
 from datetime import timedelta
 from importlib.metadata import PackageNotFoundError, version
 from typing import Any, Callable
+from urllib.parse import urlparse
 
 import cachier
 
@@ -134,6 +135,16 @@ class _Config:
 
     def validate(self) -> None:
         """Validate the current configuration values."""
+        parsed_base = urlparse(self.base_url)
+        if parsed_base.scheme not in {"http", "https"} or not parsed_base.netloc:
+            raise ConfigurationError(
+                f"base_url must be an absolute http(s) URL, got: {self.base_url!r}"
+            )
+        if any(c in self.user_agent for c in ("\r", "\n")):
+            raise ConfigurationError("user_agent must not contain CR/LF characters")
+        if not self.cache_dir:
+            raise ConfigurationError("cache_dir must be a non-empty string")
+
         if self.timeout <= 0:
             raise ConfigurationError("timeout must be positive")
         if self.max_retries < 0:

--- a/src/usaspending/config.py
+++ b/src/usaspending/config.py
@@ -45,6 +45,12 @@ class _Config:
         # Default settings are defined here as instance attributes
         self.base_url: str = "https://api.usaspending.gov/api/v2/"
         self.user_agent: str = f"usaspending-orm-python/{_resolve_version()}"
+        # Hostnames the library will fetch binary downloads from. The API
+        # returns absolute file_url values; restricting them to a known
+        # allow-list prevents SSRF if the response is tampered with.
+        self.allowed_download_hosts: frozenset[str] = frozenset(
+            {"api.usaspending.gov", "files.usaspending.gov"}
+        )
         self.timeout: int = 30
         self.max_retries: int = 3
         self.retry_delay: float = 10.0

--- a/src/usaspending/download/manager.py
+++ b/src/usaspending/download/manager.py
@@ -8,7 +8,9 @@ and extracting their contents.
 
 from __future__ import annotations
 
+import ntpath
 import os
+import posixpath
 import zipfile
 from typing import TYPE_CHECKING
 
@@ -128,22 +130,29 @@ class DownloadManager:
         """
         logger.info(f"Unzipping {zip_path} to {extract_dir}")
 
-        # Resolve to absolute path for security comparison
+        # Resolve to absolute path for security comparison.
         extract_dir = os.path.realpath(extract_dir)
 
-        if not os.path.exists(extract_dir):
-            os.makedirs(extract_dir)
+        # Create with restrictive permissions so extracted CSVs are not
+        # readable/writable by other local users on shared hosts.
+        os.makedirs(extract_dir, mode=0o700, exist_ok=True)
 
         try:
             with zipfile.ZipFile(zip_path, "r") as zip_ref:
-                # Validate all paths before extraction (ZipSlip protection)
+                # ZipSlip protection: reject absolute paths (POSIX or Windows,
+                # including drive letters and UNC prefixes) and any relative
+                # member that normalizes outside extract_dir. Because
+                # extract_dir was realpath'd above, normpath is sufficient
+                # and avoids per-member stat syscalls.
+                extract_prefix = extract_dir + os.sep
                 for member in zip_ref.namelist():
-                    member_path = os.path.realpath(os.path.join(extract_dir, member))
-                    # Ensure extracted path is within extract_dir
-                    if (
-                        not member_path.startswith(extract_dir + os.sep)
-                        and member_path != extract_dir
-                    ):
+                    if posixpath.isabs(member) or ntpath.isabs(member):
+                        raise DownloadError(
+                            f"Refusing absolute path in ZIP archive: {member}",
+                            file_name=os.path.basename(zip_path),
+                        )
+                    member_path = os.path.normpath(os.path.join(extract_dir, member))
+                    if member_path != extract_dir and not member_path.startswith(extract_prefix):
                         raise DownloadError(
                             f"Attempted path traversal in ZIP archive: {member}",
                             file_name=os.path.basename(zip_path),

--- a/src/usaspending/exceptions.py
+++ b/src/usaspending/exceptions.py
@@ -152,7 +152,7 @@ class RateLimitError(USASpendingError):
         self.retry_after = retry_after
 
 
-class ValidationError(USASpendingError):
+class ValidationError(USASpendingError, ValueError):
     """Raised when input validation fails.
 
     This exception is raised when user-provided parameters fail validation
@@ -166,6 +166,10 @@ class ValidationError(USASpendingError):
         - Invalid page_size (must be 1-100)
         - Invalid sort field for the query type
         - Invalid award type filter
+
+    Inherits from both ``USASpendingError`` and the built-in ``ValueError``,
+    so callers who previously caught ``ValueError`` for malformed inputs
+    continue to work unchanged.
 
     Example:
         Handling validation errors::

--- a/src/usaspending/models/agency.py
+++ b/src/usaspending/models/agency.py
@@ -217,7 +217,7 @@ class Agency(LazyRecord):
         return self._lazy_get("abbreviation")
 
     @property
-    def id(self):
+    def id(self) -> int | None:
         """Internal identifier from USASpending.gov.
 
         Returns:
@@ -400,8 +400,8 @@ class Agency(LazyRecord):
         obligations = self.get_value(["total_obligations", "obligations"])
         if not obligations:
             # If not present, fetch from award summary
-            obligations = self.get_obligations()
-        return obligations
+            return self.get_obligations()
+        return to_decimal(obligations)
 
     @cached_property
     def latest_action_date(self) -> date | None:
@@ -418,7 +418,8 @@ class Agency(LazyRecord):
         # If not, fetch from agency award summary endpoint
         if not latest_action_date_string:
             summary = self._get_award_summary()
-            latest_action_date_string = summary.get("latest_action_date")
+            if summary:
+                latest_action_date_string = summary.get("latest_action_date")
 
         return to_date(latest_action_date_string)
 
@@ -521,7 +522,7 @@ class Agency(LazyRecord):
         fiscal_year: int | None = None,
         agency_type: str = "awarding",
         award_type_codes: list[str] | None = None,
-    ) -> float | None:
+    ) -> Decimal | None:
         """Get obligations for this agency, optionally filtered.
 
         Args:
@@ -533,7 +534,7 @@ class Agency(LazyRecord):
                 If None, includes all award types.
 
         Returns:
-            Optional[float]: Total obligations amount as a float,
+            Optional[Decimal]: Total obligations amount as a Decimal,
             or None if unavailable due to missing data or API error.
         """
 

--- a/src/usaspending/models/award.py
+++ b/src/usaspending/models/award.py
@@ -170,33 +170,30 @@ class Award(LazyRecord):
         if not gen_id:
             return None
 
-        try:
-            parts = gen_id.split("_")
+        parts = gen_id.split("_")
 
-            # Validate minimum parts based on format
-            if len(parts) < 3:
-                return None
-
-            prefix = "_".join(parts[:2])  # e.g., "CONT_AWD" or "ASST_NON"
-
-            # Validate expected number of parts for each format
-            if (
-                (prefix == "CONT_AWD" and len(parts) != 6)
-                or (prefix == "CONT_IDV" and len(parts) != 4)
-                or (prefix in ("ASST_NON", "ASST_AGG") and len(parts) != 4)
-                or prefix not in ("CONT_AWD", "CONT_IDV", "ASST_NON", "ASST_AGG")
-            ):
-                return None
-
-            identifier = parts[2]  # The actual ID is always the 3rd segment
-
-            # Don't return placeholder values
-            if identifier == "-NONE-" or not identifier:
-                return None
-
-            return identifier
-        except (IndexError, AttributeError):
+        # Validate minimum parts based on format
+        if len(parts) < 3:
             return None
+
+        prefix = "_".join(parts[:2])  # e.g., "CONT_AWD" or "ASST_NON"
+
+        # Validate expected number of parts for each format
+        if (
+            (prefix == "CONT_AWD" and len(parts) != 6)
+            or (prefix == "CONT_IDV" and len(parts) != 4)
+            or (prefix in ("ASST_NON", "ASST_AGG") and len(parts) != 4)
+            or prefix not in ("CONT_AWD", "CONT_IDV", "ASST_NON", "ASST_AGG")
+        ):
+            return None
+
+        identifier = parts[2]  # The actual ID is always the 3rd segment
+
+        # Don't return placeholder values
+        if identifier == "-NONE-" or not identifier:
+            return None
+
+        return identifier
 
     @property
     def award_identifier(self) -> str:
@@ -435,7 +432,7 @@ class Award(LazyRecord):
             self._lazy_get("infrastructure_outlays", "Infrastructure Outlays", default=0)
         ) or Decimal("0.00")
 
-    # Helper properties properties. These often map to field names returned by
+    # Helper properties. These often map to field names returned by
     # the spending_by_award/Award Search results, or provide general access methods
     # that are common across award types.
 
@@ -736,8 +733,6 @@ class Award(LazyRecord):
         if office_name:
             enhanced_subtier_data["office_agency_name"] = office_name
 
-        from .subtier_agency import SubTierAgency
-
         return SubTierAgency(enhanced_subtier_data, self._client)
 
     @cached_property
@@ -761,8 +756,6 @@ class Award(LazyRecord):
         office_name = data.get("office_agency_name")
         if office_name:
             enhanced_subtier_data["office_agency_name"] = office_name
-
-        from .subtier_agency import SubTierAgency
 
         return SubTierAgency(enhanced_subtier_data, self._client)
 

--- a/src/usaspending/queries/award_accounts_query.py
+++ b/src/usaspending/queries/award_accounts_query.py
@@ -58,7 +58,6 @@ class AwardAccountsQuery(QueryBuilder["AwardAccount"]):
         self._award_id: str | None = None
         self._sort_field: str = "federal_account"
         self._sort_order: str = "desc"
-        self._cached_count: int | None = None
 
     @property
     def _endpoint(self) -> str:
@@ -71,7 +70,6 @@ class AwardAccountsQuery(QueryBuilder["AwardAccount"]):
         clone._award_id = self._award_id
         clone._sort_field = self._sort_field
         clone._sort_order = self._sort_order
-        clone._cached_count = self._cached_count
         return clone
 
     def _build_payload(self, page: int) -> dict[str, Any]:

--- a/src/usaspending/queries/awards_search.py
+++ b/src/usaspending/queries/awards_search.py
@@ -118,9 +118,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from ..client import USASpendingClient
 from ..exceptions import ValidationError
-from ..logging_config import USASpendingLogger
+from ..logging_config import USASpendingLogger, log_query_execution
 from ..models import Award
 from ..models.award_factory import create_award
 
@@ -163,19 +162,6 @@ class AwardsSearch(SearchQueryBuilder["Award"]):
     See module docstring for detailed usage examples.
     """
 
-    def __init__(self, client: USASpendingClient):
-        """
-        Initialize the AwardsSearch query builder.
-
-        Args:
-            client: The USASpending client instance for API communication.
-
-        Example:
-            >>> client = USASpendingClient()
-            >>> search = AwardsSearch(client)
-        """
-        super().__init__(client)
-
     @property
     def _endpoint(self) -> str:
         """
@@ -185,20 +171,6 @@ class AwardsSearch(SearchQueryBuilder["Award"]):
             str: The endpoint path '/search/spending_by_award/'.
         """
         return "/search/spending_by_award/"
-
-    def _clone(self) -> AwardsSearch:
-        """
-        Create an immutable copy of the query builder.
-
-        This method ensures that all filter operations return new instances,
-        maintaining immutability of the query builder.
-
-        Returns:
-            AwardsSearch: A new instance with copied filter objects.
-        """
-        clone = super()._clone()
-        clone._filter_objects = self._filter_objects.copy()
-        return clone
 
     def _build_payload(self, page: int) -> dict[str, Any]:
         """
@@ -387,8 +359,6 @@ class AwardsSearch(SearchQueryBuilder["Award"]):
         payload = {
             "filters": final_filters,
         }
-
-        from ..logging_config import log_query_execution
 
         log_query_execution(
             logger,

--- a/src/usaspending/queries/filters.py
+++ b/src/usaspending/queries/filters.py
@@ -336,36 +336,6 @@ def parse_location_scope(scope: str) -> LocationScope:
     return parse_enum_value(scope, LocationScope, "scope", normalize=False)
 
 
-def parse_agency_type(agency_type: str) -> AgencyType:
-    """Convert a string to an AgencyType enum value.
-
-    Args:
-        agency_type: Either "awarding" or "funding" (case-insensitive).
-
-    Returns:
-        AgencyType: The corresponding enum value.
-
-    Raises:
-        ValidationError: If agency_type is not "awarding" or "funding".
-    """
-    return parse_enum_value(agency_type, AgencyType, "agency_type", normalize=False)
-
-
-def parse_agency_tier(tier: str) -> AgencyTier:
-    """Convert a string to an AgencyTier enum value.
-
-    Args:
-        tier: Either "toptier" or "subtier" (case-insensitive).
-
-    Returns:
-        AgencyTier: The corresponding enum value.
-
-    Raises:
-        ValidationError: If tier is not "toptier" or "subtier".
-    """
-    return parse_enum_value(tier, AgencyTier, "tier", normalize=False)
-
-
 def parse_award_date_type(date_type: str) -> AwardDateType:
     """Convert a string to an AwardDateType enum value.
 
@@ -496,8 +466,6 @@ def parse_agency_spec(agency: dict[str, str]) -> AgencySpec:
     Raises:
         ValidationError: If required fields are missing or invalid.
     """
-    from ..exceptions import ValidationError
-
     # Validate required fields
     if "name" not in agency:
         raise ValidationError("Agency specification must include 'name' field")

--- a/src/usaspending/queries/funding_search.py
+++ b/src/usaspending/queries/funding_search.py
@@ -46,7 +46,7 @@ class FundingSearch(QueryBuilder["Funding"]):
             client: The USASpending client instance.
         """
         super().__init__(client)
-        self._award_id: str = None
+        self._award_id: str | None = None
         self._sort_field: str = "reporting_fiscal_date"
         self._sort_order: str = "desc"
 

--- a/src/usaspending/queries/idv_child_awards.py
+++ b/src/usaspending/queries/idv_child_awards.py
@@ -72,8 +72,7 @@ class IDVChildAwardsSearch(QueryBuilder["Award"]):
     def _clone(self) -> IDVChildAwardsSearch:
         """Creates an immutable copy of the query builder."""
         clone = IDVChildAwardsSearch(self._client, self._award_id)
-        clone._total_limit = self._total_limit
-        clone._page_size = self._page_size
+        self._copy_base_state_into(clone)
         clone._sort_field = self._sort_field
         clone._sort_order = self._sort_order
         clone._idv_award_type = self._idv_award_type

--- a/src/usaspending/queries/query_builder.py
+++ b/src/usaspending/queries/query_builder.py
@@ -323,15 +323,25 @@ class QueryBuilder(BaseQuery[T], ABC):
 
         return response
 
-    def _clone(self) -> QueryBuilder[T]:
-        """Create a copy for method chaining."""
-        clone = self.__class__(self._client)
+    def _copy_base_state_into(self, clone: QueryBuilder[T]) -> None:
+        """Copy QueryBuilder-owned state into an already-constructed clone.
+
+        Subclasses whose constructors require extra arguments (e.g., a
+        required ``award_id``) cannot call ``super()._clone()``. They build
+        the clone themselves and call this to inherit base-class state, so
+        base-class changes propagate without per-subclass edits.
+        """
         clone._filter_objects = self._filter_objects.copy()
         clone._page_size = self._page_size
         clone._total_limit = self._total_limit
         clone._max_pages = self._max_pages
         clone._order_by = self._order_by
         clone._order_direction = self._order_direction
+
+    def _clone(self) -> QueryBuilder[T]:
+        """Create a copy for method chaining."""
+        clone = self.__class__(self._client)
+        self._copy_base_state_into(clone)
         return clone
 
 

--- a/src/usaspending/queries/query_builder.py
+++ b/src/usaspending/queries/query_builder.py
@@ -302,11 +302,6 @@ class QueryBuilder(BaseQuery[T], ABC):
 
         return final_filters
 
-    def _fetch_page(self, page: int) -> list[dict[str, Any]]:
-        """Fetch a single page of results."""
-        response = self._execute_query(page)
-        return response.get("results", [])
-
     def _execute_query(self, page: int) -> dict[str, Any]:
         """Execute the query and return raw response."""
         query_type = self.__class__.__name__

--- a/src/usaspending/queries/query_builder.py
+++ b/src/usaspending/queries/query_builder.py
@@ -470,6 +470,10 @@ class SearchQueryBuilder(QueryBuilder[T], ABC):
                 f"end_date {end_date} is before the minimum supported date "
                 f"{MIN_API_DATE} (FY2008). USASpending.gov data begins in FY2008."
             )
+        if end_date < start_date:
+            raise ValidationError(
+                f"end_date {end_date} must be on or after start_date {start_date}."
+            )
 
         # Convert string date_type to enum if needed
         date_type_enum = None

--- a/src/usaspending/queries/subawards_search.py
+++ b/src/usaspending/queries/subawards_search.py
@@ -37,13 +37,7 @@ class SubAwardsSearch(AwardsSearch):
 
     def _clone(self) -> SubAwardsSearch:
         """Creates an immutable copy of the query builder."""
-        clone = SubAwardsSearch(self._client)
-        clone._filter_objects = self._filter_objects.copy()
-        clone._page_size = self._page_size
-        clone._total_limit = self._total_limit
-        clone._max_pages = self._max_pages
-        clone._order_by = self._order_by
-        clone._order_direction = self._order_direction
+        clone = super()._clone()
         clone._award_id = self._award_id
         return clone
 

--- a/src/usaspending/queries/transactions_search.py
+++ b/src/usaspending/queries/transactions_search.py
@@ -45,9 +45,9 @@ class TransactionsSearch(QueryBuilder["Transaction"]):
             client: The USASpending client instance.
         """
         super().__init__(client)
-        self._award_id: str = None
+        self._award_id: str | None = None
         # Client-side filters (not supported by API)
-        self._client_filters = {}
+        self._client_filters: dict[str, Any] = {}
 
     @property
     def _endpoint(self) -> str:

--- a/src/usaspending/resources/award_resource.py
+++ b/src/usaspending/resources/award_resource.py
@@ -31,7 +31,7 @@ class AwardResource(BaseResource):
             Award model instance
 
         Raises:
-            : If generated_award_id is invalid
+            ValidationError: If generated_award_id is invalid
             APIError: If award not found
         """
         logger.debug(f"Retrieving award by ID: {generated_award_id}")

--- a/src/usaspending/resources/recipients_resource.py
+++ b/src/usaspending/resources/recipients_resource.py
@@ -24,8 +24,12 @@ class RecipientsResource(BaseResource):
         self,
         recipient_id: str,
         year: int | str | None = None,
-    ) -> Recipient | None:
+    ) -> Recipient:
         """Retrieve a single recipient by ID.
+
+        Direct-ID lookups raise on miss rather than returning None. For the
+        search-delegation convention (which returns Optional), see
+        ``find_by_duns`` and ``find_by_uei``.
 
         Args:
             recipient_id: Unique recipient identifier (hash + level suffix,

--- a/src/usaspending/utils/formatter.py
+++ b/src/usaspending/utils/formatter.py
@@ -108,26 +108,6 @@ def current_fiscal_year() -> int:
         return current_date.year + 1
 
 
-def get_past_fiscal_years(num_years: int = 3) -> list[int]:
-    """
-    Get the past N fiscal years.
-    In the US, the federal fiscal year starts on October 1.
-
-    Args:
-        num_years: Number of past fiscal years to return
-
-    Returns:
-        List: List of fiscal years, starting with the most recent
-    """
-    current_date = datetime.now()
-    current_year = current_date.year
-
-    # We always want the last completed fiscal year
-    current_fiscal_year = current_year - 1 if current_date.month < 10 else current_year
-
-    return [current_fiscal_year - i for i in range(num_years)]
-
-
 def to_decimal(x: Any) -> Decimal | None:
     """Convert input to a Decimal with 2 decimal places using banker's rounding.
 
@@ -182,60 +162,6 @@ def to_int(x: Any) -> int | None:
     except (TypeError, ValueError):
         return None
 
-
-# --- Configuration ---
-# Set of acronyms and initialisms to always keep uppercase.
-# This could be loaded from a config file or environment variables in a larger application.
-DEFAULT_KEEP_UPPERCASE: set[str] = {
-    # Common Business / Legal
-    "LLC",
-    "INC",
-    "LLP",
-    "LTD",
-    "L.L.C.",
-    "I.N.C.",
-    "L.L.P.",
-    "L.T.D.",
-    # Geographical / Governmental
-    "USA",
-    "US",
-    "UK",
-    # Organizations / Agencies
-    "NASA",
-    "ESA",
-    "JAXA",
-    # NASA Facilities & Major Programs (add more as needed)
-    "JPL",  # Jet Propulsion Laboratory
-    "JSC",  # Johnson Space Center
-    "KSC",  # Kennedy Space Center
-    "GSFC",  # Goddard Space Flight Center
-    "MSFC",  # Marshall Space Flight Center
-    "ARC",  # Ames Research Center
-    "GRC",  # Glenn Research Center
-    "LARC",  # Langley Research Center (or LaRC - handled by case-insensitive check)
-    "AFRC",  # Armstrong Flight Research Center
-    "SSC",  # Stennis Space Center
-    "ISS",  # International Space Station
-    "JWST",  # James Webb Space Telescope
-    # Specific examples from user input
-    "CSOS",
-    "CL",
-    "FL",
-    "FPRW",
-    "PADF",
-    "ICAT",
-    "ICATEQ",
-    "AC"  # For A.C. style
-    # Add other common contract/technical acronyms as needed
-    "RFQ",
-    "RFP",
-    "SOW",
-    "CDR",
-    "PDR",
-    "QA",
-    "PI",
-    "COTS",
-}
 
 # Maximum length for parenthesized text to be uppercased
 PAREN_UPPERCASE_MAX_LEN: int = 9  # Fewer than 10 characters
@@ -505,12 +431,6 @@ class TextFormatter:
             word = normalized_words[word.upper()]
 
         return cls._preserve_special_case(word)
-
-
-# Define a callback function for custom word handling
-def custom_titlecase_callback(word, **kwargs):
-    """Custom titlecase callback using YAML configuration."""
-    return TextFormatter.titlecase_callback(word, **kwargs)
 
 
 def contracts_titlecase(text):

--- a/src/usaspending/utils/formatter.py
+++ b/src/usaspending/utils/formatter.py
@@ -39,7 +39,8 @@ def to_date(date_string: str | date | None) -> date | None:
     if not date_string:
         return None
 
-    # If already a date object, return as-is
+    if isinstance(date_string, datetime):
+        return date_string.date()
     if isinstance(date_string, date):
         return date_string
 

--- a/src/usaspending/utils/formatter.py
+++ b/src/usaspending/utils/formatter.py
@@ -85,7 +85,7 @@ def round_to_millions(amount: int | float | Decimal) -> str:
         return "$0.00"
     elif amount >= 1_000_000_000:
         return f"${amount / 1_000_000_000:,.1f} billion"
-    elif amount >= 10_000_000 or amount >= 1_000_000:
+    elif amount >= 1_000_000:
         return f"${amount / 1_000_000:,.1f} million"
     else:
         return f"${amount:,.2f}"

--- a/src/usaspending/utils/rate_limit.py
+++ b/src/usaspending/utils/rate_limit.py
@@ -6,6 +6,7 @@ import threading
 import time
 from collections import deque
 
+from ..exceptions import ValidationError
 from ..logging_config import USASpendingLogger
 
 logger = USASpendingLogger.get_logger(__name__)
@@ -30,9 +31,9 @@ class RateLimiter:
             period: Time period in seconds
         """
         if max_calls <= 0:
-            raise ValueError("max_calls must be positive")
+            raise ValidationError("max_calls must be positive")
         if period <= 0:
-            raise ValueError("period must be positive")
+            raise ValidationError("period must be positive")
 
         self.max_calls = max_calls
         self.period = period

--- a/tests/mocks/README.md
+++ b/tests/mocks/README.md
@@ -39,11 +39,11 @@ def test_award_search(mock_client):
             "page_metadata": {"hasNext": False}
         }
     ]
-    
+
     # Test execution
     results = list(mock_client.awards.search().award_type_codes("A"))
     assert len(results) == 3
-    
+
     # Manual assertion
     assert mock_client._make_request.call_count == 2
 ```
@@ -55,14 +55,14 @@ def test_award_search(mock_usa_client):
     # Simple mock setup
     mock_usa_client.mock_award_search([
         {"Award ID": "1"},
-        {"Award ID": "2"}, 
+        {"Award ID": "2"},
         {"Award ID": "3"}
     ])
-    
+
     # Test execution
     results = list(mock_usa_client.awards.search().award_type_codes("A"))
     assert len(results) == 3
-    
+
     # Built-in assertion
     assert mock_usa_client.get_request_count() == 1  # Auto-paginated
 ```
@@ -77,15 +77,15 @@ def test_award_search(mock_usa_client):
         {"Award ID": "123", "Recipient Name": "SpaceX", "Award Amount": 1000000},
         {"Award ID": "456", "Recipient Name": "Blue Origin", "Award Amount": 2000000}
     ])
-    
+
     results = list(
         mock_usa_client.awards.search()
         .award_type_codes("A")
         .keywords("space")
     )
-    
+
     assert len(results) == 2
-    assert results[0]._data["Recipient Name"] == "SpaceX"
+    assert results[0].raw["Recipient Name"] == "SpaceX"
 ```
 
 ### Pagination Testing
@@ -142,20 +142,20 @@ def test_with_fixture(mock_usa_client):
 ```python
 def test_request_tracking(mock_usa_client):
     mock_usa_client.mock_award_search([])
-    
+
     list(
         mock_usa_client.awards.search()
         .award_type_codes("A")
         .keywords("space")
     )
-    
+
     # Check what was sent
     last_request = mock_usa_client.get_last_request()
     payload = last_request["json"]
-    
+
     assert payload["filters"]["award_type_codes"] == ["A"]
     assert payload["filters"]["keywords"] == ["space"]
-    
+
     # Or use assertion helper
     mock_usa_client.assert_called_with(
         "/search/spending_by_award/",
@@ -211,6 +211,7 @@ def test_rate_limiting(mock_usa_client):
 ### MockUSASpendingClient
 
 #### Response Setup Methods
+
 - `set_response(endpoint, response_data, status_code=200)`: Set single response
 - `set_paginated_response(endpoint, items, page_size=100)`: Auto-paginate items
 - `set_fixture_response(endpoint, fixture_name)`: Load from fixture file
@@ -218,6 +219,7 @@ def test_rate_limiting(mock_usa_client):
 - `add_response_sequence(endpoint, responses)`: Multiple responses in sequence
 
 #### Convenience Mock Methods
+
 - `mock_award_search(awards, page_size=100)`: Convenience for award search
 - `mock_award_count(**counts)`: Convenience for award counts
 - `mock_award_detail(award_id, **data)`: Convenience for award detail
@@ -228,18 +230,22 @@ def test_rate_limiting(mock_usa_client):
 - `mock_download_status(file_name, status, custom_data)`: Mock download status response
 
 #### Request Tracking
+
 - `get_request_count(endpoint=None)`: Get number of requests made
 - `get_last_request(endpoint=None)`: Get last request data
 - `assert_called_with(endpoint, method, json, params)`: Assert specific request
 
 #### Rate Limiting Simulation
+
 - `simulate_rate_limit(delay=0.1)`: Enable rate limiting with delay between requests
 - `disable_rate_limit()`: Disable rate limiting simulation
 
 #### Utility Methods
+
 - `reset()`: Clear all mock state
 
 #### Endpoint Constants
+
 - `Endpoints` class: Contains constants for all API endpoints (e.g., `MockUSASpendingClient.Endpoints.AWARD_SEARCH`)
 
 ### ResponseBuilder
@@ -285,12 +291,14 @@ python -m pytest tests/test_mock_client_example.py -v
 ## Quick Start
 
 1. Use the `mock_usa_client` fixture in your tests:
+
    ```python
    def test_my_feature(mock_usa_client):
        # Your test here
    ```
 
 2. Set up simple responses:
+
    ```python
    mock_usa_client.mock_award_search([
        {"Award ID": "123", "Recipient Name": "Test Corp"}
@@ -298,6 +306,7 @@ python -m pytest tests/test_mock_client_example.py -v
    ```
 
 3. Execute your test logic:
+
    ```python
    results = list(mock_usa_client.awards.search().award_type_codes("A"))
    assert len(results) == 1

--- a/tests/models/test_agency.py
+++ b/tests/models/test_agency.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import date
+from decimal import Decimal
 from unittest.mock import Mock
 
 from tests.utils import assert_decimal_equal
@@ -110,7 +111,7 @@ class TestAgencyObligationMethodsNewStructure:
         agency = Agency(data, mock_usa_client)
 
         assert agency.obligations == agency.total_obligations
-        assert isinstance(agency.obligations, float)
+        assert isinstance(agency.obligations, Decimal)
 
     def test_cached_obligations_from_award_summary(
         self, mock_usa_client, agency_award_summary_fixture_data
@@ -156,6 +157,15 @@ class TestAgencyObligationMethodsNewStructure:
         agency = Agency(data, mock_usa_client)
 
         assert agency.code == "080"
+
+    def test_latest_action_date_none_when_summary_missing(self, mock_usa_client):
+        """Regression: latest_action_date previously crashed with
+        ``AttributeError: 'NoneType' object has no attribute 'get'`` when
+        ``_get_award_summary()`` returned None (e.g., missing toptier_code).
+        """
+        agency = Agency({}, mock_usa_client)
+        agency._get_award_summary = Mock(return_value=None)
+        assert agency.latest_action_date is None
 
 
 class TestAgencyLazyLoadingNewStructure:

--- a/tests/queries/test_idv_child_awards.py
+++ b/tests/queries/test_idv_child_awards.py
@@ -225,6 +225,27 @@ class TestClone:
         assert clone._total_limit == 50
         assert clone is not search
 
+    def test_clone_preserves_base_query_state(self, mock_usa_client):
+        """_clone must copy base-class fields too.
+
+        Regression: an earlier version copied only class-specific fields
+        and silently dropped ``_max_pages``, ``_order_by``,
+        ``_order_direction``, and ``_page_size`` set on the parent.
+        """
+        search = (
+            IDVChildAwardsSearch(mock_usa_client, "CONT_IDV_123")
+            .page_size(25)
+            .max_pages(3)
+            .order_by("piid", "asc")
+        )
+
+        clone = search._clone()
+
+        assert clone._page_size == search._page_size
+        assert clone._max_pages == search._max_pages
+        assert clone._order_by == search._order_by
+        assert clone._order_direction == search._order_direction
+
 
 class TestTransformResult:
     """Test result transformation."""

--- a/tests/queries/test_search_query_builder.py
+++ b/tests/queries/test_search_query_builder.py
@@ -127,6 +127,19 @@ class TestTimePeriodFilter:
         )
         assert len(result._filter_objects) == 1
 
+    def test_time_period_rejects_end_before_start(self, search_builder):
+        """Invalid ranges (end < start) are rejected.
+
+        Regression: previously only the FY2008 floor was checked; nonsensical
+        ranges such as ``time_period("2024-06-01", "2024-01-01")`` passed
+        validation and were silently sent to the API.
+        """
+        with pytest.raises(ValidationError, match="must be on or after start_date"):
+            search_builder.time_period(
+                start_date="2024-06-01",
+                end_date="2024-01-01",
+            )
+
 
 class TestFiscalYearFilter:
     """Test fiscal_year convenience method."""

--- a/tests/test_client_security.py
+++ b/tests/test_client_security.py
@@ -1,0 +1,59 @@
+"""Security-relevant behavior of the core client.
+
+Covers the download-URL allow-list and config validation hardening
+introduced in v0.7.1.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from usaspending.client import USASpendingClient
+from usaspending.exceptions import ConfigurationError, DownloadError
+
+
+def test_download_binary_rejects_host_not_in_allow_list(tmp_path, client_config) -> None:
+    """Binary downloads outside the allow-list raise DownloadError.
+
+    Regression: before v0.7.1 any absolute URL in an API response would be
+    fetched verbatim, allowing SSRF via tampered responses (e.g., redirect
+    to metadata services or attacker-controlled hosts).
+    """
+    client_config(allowed_download_hosts=frozenset({"files.usaspending.gov"}))
+
+    client = USASpendingClient()
+    try:
+        with pytest.raises(DownloadError, match=r"not in .*allowed_download_hosts"):
+            client._download_binary_file(
+                "https://attacker.example.com/payload.zip",
+                str(tmp_path / "out.zip"),
+            )
+    finally:
+        client.close()
+
+
+def test_download_binary_rejects_non_https(tmp_path, client_config) -> None:
+    """Non-HTTPS downloads are rejected even if the host is allow-listed."""
+    client_config(allowed_download_hosts=frozenset({"files.usaspending.gov"}))
+
+    client = USASpendingClient()
+    try:
+        with pytest.raises(DownloadError, match="non-https scheme"):
+            client._download_binary_file(
+                "http://files.usaspending.gov/report.zip",
+                str(tmp_path / "out.zip"),
+            )
+    finally:
+        client.close()
+
+
+def test_config_rejects_non_url_base_url(client_config) -> None:
+    """config.validate now rejects base_url that is not an http(s) URL."""
+    with pytest.raises(ConfigurationError, match="base_url must be an absolute"):
+        client_config(base_url="not-a-url")
+
+
+def test_config_rejects_crlf_in_user_agent(client_config) -> None:
+    """CRLF in user_agent could enable header-injection into logs or proxies."""
+    with pytest.raises(ConfigurationError, match="CR/LF"):
+        client_config(user_agent="usaspending-orm/0.7.1\r\nX-Injected: yes")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -124,7 +124,15 @@ class TestSpendingResourceIntegration:
 
     def test_spending_by_recipient(self, client):
         """Test spending by recipient."""
-        results = list(client.spending.search().by_recipient().fiscal_year(2024).limit(3))
+        # Narrow to a single agency so the upstream aggregation returns promptly;
+        # unfiltered transaction-level recipient queries time out server-side.
+        results = list(
+            client.spending.search()
+            .by_recipient()
+            .agency("National Aeronautics and Space Administration")
+            .fiscal_year(2024)
+            .limit(3)
+        )
         assert len(results) > 0
         assert results[0].name is not None
         assert results[0].amount is not None

--- a/tests/utils/test_formatter.py
+++ b/tests/utils/test_formatter.py
@@ -284,3 +284,18 @@ class TestToDate:
         # Second conversion should not raise TypeError
         second_conversion = to_date(first_conversion)
         assert second_conversion == date(2024, 8, 12)
+
+    def test_datetime_object_returns_date_portion(self):
+        """datetime input is narrowed to its date() portion.
+
+        Regression: datetime is a subclass of date, so the prior
+        ``isinstance(x, date)`` check let datetimes through unchanged,
+        leaking a datetime out of a function typed ``date | None``.
+        """
+        from datetime import date, datetime
+
+        dt = datetime(2025, 8, 29, 14, 30, 45)
+        result = to_date(dt)
+
+        assert type(result) is date
+        assert result == date(2025, 8, 29)

--- a/uv.lock
+++ b/uv.lock
@@ -475,7 +475,7 @@ wheels = [
 
 [[package]]
 name = "usaspending-orm"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "cachier" },


### PR DESCRIPTION
## Summary

Small release focused on correctness fixes, security hardening, and public-API consistency. Sixteen atomic commits; no API breaks.

### Highlights

**Real bugs fixed**
- `to_date()` no longer returns `datetime` objects unchanged (was leaking the subclass out of a function typed `date | None`).
- Three query-builder `_clone()` implementations had drifted from the base contract: `IDVChildAwardsSearch` silently dropped `_filter_objects` / `_max_pages` / order state on chaining; `SubAwardsSearch` reimplemented base-clone logic; `AwardAccountsQuery` copied a stale `_cached_count`. All fixed via a new `QueryBuilder._copy_base_state_into` hook.
- `Agency.latest_action_date` crashed with `AttributeError` when the award-summary endpoint returned no data.
- `Agency.total_obligations` and `Agency.get_obligations` had type annotations that didn't match runtime behavior; corrected.
- `time_period(start, end)` now rejects inverted ranges (`end < start`) instead of silently sending them to the API.
- Removed an unused `DEFAULT_KEEP_UPPERCASE` set that contained a latent missing-comma bug concatenating `"AC"` and `"RFQ"` into a single `"ACRFQ"` entry.

**Security hardening**
- Binary downloads (`_download_binary_file`) now enforce `https` and a new `config.allowed_download_hosts` allow-list, mitigating SSRF via tampered API responses.
- File-backed cache directory is created/enforced at `0700` (previously inherited the process umask — pickle-load in a shared-host cache dir was a code-execution risk).
- ZIP extraction creates extract dirs at `0700`, uses stdlib `posixpath.isabs` / `ntpath.isabs` for absolute-path detection (covers Windows drive letters and UNC prefixes), and switches from per-member `realpath` to a `normpath` + prefix check.

**Public API / consistency**
- Export `DetachedInstanceError` from the top-level package (documented in README but previously unreachable via `from usaspending import ...`).
- `ValidationError` now inherits from both `USASpendingError` and built-in `ValueError`, so existing `except ValueError` sites keep working while the library can consistently raise `ValidationError`. `RateLimiter` migrated from bare `ValueError`.
- `find_by_recipient_id` annotation narrowed to non-Optional to match its raises-on-miss behavior (direct-ID lookup convention).
- Stricter `config.validate`: rejects malformed `base_url`, CR/LF in `user_agent`, empty `cache_dir`.

**Integration test bound** (`test_spending_by_recipient`): added an agency filter so the unfiltered query doesn't time out server-side.

See `CHANGELOG.md` for the full list.

## Test plan

- [x] `uv run pytest` — 1563 passed, 2 skipped
- [x] `uv run pytest -m integration` — 15 passed against live API in 6.2s
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — 167 files formatted

## Merge strategy

Please merge via **"Create a merge commit"** or **"Rebase and merge"** to preserve the 16 atomic commits. Avoid squash-merge — each commit is a self-contained decision point with its own rationale.
